### PR TITLE
Add link to lexima.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vim-lexiv
 
-Small implementation of lexima
+Small implementation of [lexima.vim](https://github.com/cohama/lexima.vim)
 
 ## Installation
 


### PR DESCRIPTION
I'd like to link to [lexima.vim](https://github.com/cohama/lexima.vim) to respect the original.