### PR TITLE
Add the required VIM version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Small implementation of [lexima.vim](https://github.com/cohama/lexima.vim)
 
 ## Installation
 
+VIM 8.1 or above is required.
+
 For [vim-plug](https://github.com/junegunn/vim-plug) plugin manager:
 
 ```


### PR DESCRIPTION
vim-lexiv requires vim 8.1 or higher to call reg_executing.
https://github.com/vim/vim/commit/0b6d911e5de1a1c10a23d4c2ee1b0275c474a2dd